### PR TITLE
change fanal cache directory path

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -5,8 +5,6 @@ import (
 )
 
 const (
-	cacheDirName = "fanal"
-
 	// artifactBucket stores artifact information with artifact ID such as image ID
 	artifactBucket = "artifact"
 	// blobBucket stores os, package and library information per blob ID such as layer ID

--- a/cache/fs.go
+++ b/cache/fs.go
@@ -20,12 +20,11 @@ type FSCache struct {
 }
 
 func NewFSCache(cacheDir string) (FSCache, error) {
-	dir := filepath.Join(cacheDir, cacheDirName)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
 		return FSCache{}, xerrors.Errorf("failed to create cache dir: %w", err)
 	}
 
-	db, err := bolt.Open(filepath.Join(dir, "fanal.db"), 0600, nil)
+	db, err := bolt.Open(filepath.Join(cacheDir, "fanal.db"), 0600, nil)
 	if err != nil {
 		return FSCache{}, xerrors.Errorf("unable to open DB: %w", err)
 	}
@@ -44,7 +43,7 @@ func NewFSCache(cacheDir string) (FSCache, error) {
 
 	return FSCache{
 		db:        db,
-		directory: dir,
+		directory: cacheDir,
 	}, nil
 }
 

--- a/cache/fs_test.go
+++ b/cache/fs_test.go
@@ -19,8 +19,8 @@ import (
 func newTempDB(t *testing.T, dbPath string) (string, error) {
 	dir := t.TempDir()
 	if dbPath != "" {
-		d := filepath.Join(dir, "fanal")
-		if err := os.MkdirAll(d, 0700); err != nil {
+		d := dir
+		if err := os.MkdirAll(d, 0o700); err != nil {
 			return "", err
 		}
 
@@ -349,7 +349,7 @@ func TestFSCache_PutArtifact(t *testing.T) {
 
 			fs, err := NewFSCache(tmpDir)
 			require.NoError(t, err)
-			//defer fs.Clear()
+			// defer fs.Clear()
 
 			err = fs.PutArtifact(tt.args.imageID, tt.args.imageConfig)
 			if tt.wantErr != "" {


### PR DESCRIPTION
fanal stores its cache inside fanal directory but since zot is image repository
all directory inside zot storage should be oci layout therefore removing fanal from path.